### PR TITLE
feat(api): user should be able to retrieve all new unsold cars

### DIFF
--- a/src/controllers/car.js
+++ b/src/controllers/car.js
@@ -55,8 +55,8 @@ class Car {
       return Result.getResult(res, CarModel.getAllUnsoldAvailableCarsByRange(min, max), true);
     }
 
-    if (state && state === 'used') {
-      return Result.getResult(res, CarModel.getAllUnsoldAvailableCars('used'), true);
+    if (state && (state === 'used' || state === 'new')) {
+      return Result.getResult(res, CarModel.getAllUnsoldAvailableCars(state), true);
     }
 
     if (status) {

--- a/test/get.all.new.unsold.cars.test.js
+++ b/test/get.all.new.unsold.cars.test.js
@@ -5,7 +5,7 @@ import server from '../src/server';
 
 
 use(chaiHttp);
-describe('GET /api/v1/car?status=available&state=used', () => {
+describe('GET /api/v1/car?status=available&state=new', () => {
   const userCredentials = {
     email: 'aobikobe@gmail.com',
     password: 'password70',
@@ -24,36 +24,11 @@ describe('GET /api/v1/car?status=available&state=used', () => {
       });
   });
 
-  describe('When a user tries to retrieve all used cars without putting the value of state', () => {
-    it('should return an object with the status and error', (done) => {
-      chai.request(server)
-        .get('/api/v1/car?status=available&state').set('Authorization', token)
-        .send()
-        .end((err, res) => {
-          expect(res.body).to.have.property('status').to.equals(400);
-          expect(res.body).to.have.property('error').to.be.a('string').equals('No state value given');
-          done();
-        });
-    });
-  });
-
-  describe('When a user tries to retrieve all used cars with wrong value for state', () => {
-    it('should return an object with the status and error', (done) => {
-      chai.request(server)
-        .get('/api/v1/car?status=available&state=uyjkh').set('Authorization', token)
-        .send()
-        .end((err, res) => {
-          expect(res.body).to.have.property('status').to.equals(400);
-          expect(res.body).to.have.property('error').to.be.a('string').equals('Incorrect state value');
-          done();
-        });
-    });
-  });
 
   describe('When a user tries to retrieve all used cars ommiting status=available', () => {
     it('should return an object with the status and error', (done) => {
       chai.request(server)
-        .get('/api/v1/car?state=used').set('Authorization', token)
+        .get('/api/v1/car?state=new').set('Authorization', token)
         .send()
         .end((err, res) => {
           expect(res.body).to.have.property('status').to.equals(400);
@@ -67,7 +42,7 @@ describe('GET /api/v1/car?status=available&state=used', () => {
   describe('When a user tries to retrieve all used cars with proper detail', () => {
     it('should return an object with the status and data', (done) => {
       chai.request(server)
-        .get('/api/v1/car?status=available&state=used').set('Authorization', token)
+        .get('/api/v1/car?status=available&state=new').set('Authorization', token)
         .send()
         .end((err, res) => {
           if (res.body.data.length !== 0) {
@@ -75,7 +50,7 @@ describe('GET /api/v1/car?status=available&state=used', () => {
               expect(element).to.have.property('id');
               expect(element).to.have.property('owner');
               expect(element).to.have.property('createdOn');
-              expect(element).to.have.property('state').to.equals('used');
+              expect(element).to.have.property('state').to.equals('new');
               expect(element).to.have.property('status').to.equals('available');
               expect(element).to.have.property('price');
               expect(element).to.have.property('manufacturer');


### PR DESCRIPTION
What does this PR do?
- User  should be able to retrieve all new unsold cars

#### Description of Task to be completed?
- Add test/get.all.new.unsold.cars.test.js
- Modify src/controllers/car.js to retrieve all new available cars

#### How should this be manually tested?
- ``` npm run start:dev```
- On Postman Browser type
 ``` http:localhost:3000/api/v1/car?status=available&state=new```
- Select Get
- Press send

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166103348](https://www.pivotaltracker.com/story/show/166103348))