### PR TITLE
feat(api): user should be able to retrieve cars of a specific body type

### DIFF
--- a/src/controllers/car.js
+++ b/src/controllers/car.js
@@ -43,13 +43,18 @@ class Car {
     const {
       min, max, status, state,
     } = req.query;
+
+    const bodyType = req.query.body_type;
     const arrayQueryParameter = Object.keys(req.query);
 
-    const found = arrayQueryParameter.every(r => ['min', 'max', 'status', 'state'].indexOf(r) >= 0);
+    const found = arrayQueryParameter.every(r => ['min', 'max', 'status', 'state', 'body_type'].indexOf(r) >= 0);
     if (!found && arrayQueryParameter.length > 0) {
       return res.status(403).json({ status: 403, error: 'Invalid Query Parameter was supplied' });
     }
 
+    if (bodyType) {
+      return Result.getResult(res, CarModel.getAllCarsByBodyType(bodyType), true);
+    }
 
     if (max && min) {
       return Result.getResult(res, CarModel.getAllUnsoldAvailableCarsByRange(min, max), true);

--- a/src/helpers/custom-validator.js
+++ b/src/helpers/custom-validator.js
@@ -142,6 +142,22 @@ export const usedStatusQueryCheck = query('state').custom((value, { req }) => {
   return true;
 }).optional('nullable');
 
+export const bodyTypeQueryCheck = query('body_type').custom((value, { req }) => {
+  const queryObj = req.query;
+
+
+  isValidNumberOfParameter(queryObj, 1);
+
+  if (!queryObj.body_type) {
+    throw new Error('Body type value is missing');
+  }
+
+  return true;
+}).optional('nullable')
+  .isAlpha()
+  .withMessage('Body type should only contain alphabet')
+  .toString();
+
 
 export const priceParamCheck = param('newPrice').exists()
   .isFloat({ min: 1 })

--- a/src/models/car.js
+++ b/src/models/car.js
@@ -11,7 +11,7 @@ class Car {
       price: 1.4,
       manufacturer: 'mercedes',
       model: '2014',
-      body_type: 'trailer',
+      bodyType: 'trailer',
     },
     {
       id: 2,
@@ -22,7 +22,7 @@ class Car {
       price: 1.8,
       manufacturer: 'honda',
       model: '2015',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 3,
@@ -33,7 +33,7 @@ class Car {
       price: 2.8,
       manufacturer: 'mercedes',
       model: '2014',
-      body_type: 'suv',
+      bodyType: 'suv',
     }, {
       id: 4,
       owner: 1,
@@ -43,7 +43,7 @@ class Car {
       price: 1.9,
       manufacturer: 'mercedes',
       model: '2014',
-      body_type: 'trailer',
+      bodyType: 'trailer',
     },
     {
       id: 5,
@@ -54,7 +54,7 @@ class Car {
       price: 2.8,
       manufacturer: 'buggati',
       model: '2014',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 6,
@@ -65,7 +65,7 @@ class Car {
       price: 2.8,
       manufacturer: 'buggati',
       model: '2014',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 7,
@@ -76,7 +76,7 @@ class Car {
       price: 2.8,
       manufacturer: 'buggati',
       model: '2014',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 8,
@@ -87,7 +87,7 @@ class Car {
       price: 2.8,
       manufacturer: 'buggati',
       model: '2014',
-      body_type: 'coupe',
+      bodyType: 'jeep',
     },
     {
       id: 9,
@@ -98,7 +98,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'salon',
     },
     {
       id: 10,
@@ -109,7 +109,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'mpv',
     },
     {
       id: 11,
@@ -120,7 +120,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 12,
@@ -131,7 +131,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'wagon',
     },
     {
       id: 13,
@@ -142,7 +142,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'coupe',
     },
     {
       id: 14,
@@ -153,7 +153,7 @@ class Car {
       price: 2.8,
       manufacturer: 'volkswagen',
       model: '2016',
-      body_type: 'coupe',
+      bodyType: 'suv',
     },
     ];
     this.lastInsertId = this.cars.length;
@@ -260,6 +260,15 @@ class Car {
 
     return this.cars.reduce((acc, car) => {
       if (car.status === 'available') {
+        acc.push(car);
+      }
+      return acc;
+    }, []);
+  }
+
+  getAllCarsByBodyType(bodyType) {
+    return this.cars.reduce((acc, car) => {
+      if (car.bodyType === bodyType) {
         acc.push(car);
       }
       return acc;

--- a/src/routes/route1.js
+++ b/src/routes/route1.js
@@ -9,7 +9,7 @@ import {
   newPriceSanitizer, orderIdSanitizer, orderIdParamCheck,
   priceParamCheck, carIdParamCheck, carStatusParamCheck, carIdSanitizer,
   statusQueryCheck, minQueryCheck, maxQueryCheck, arefieldsTheSameQueryCheck,
-  priceOptionalCheck, usedStatusQueryCheck,
+  priceOptionalCheck, usedStatusQueryCheck, bodyTypeQueryCheck,
 } from '../helpers/custom-validator';
 
 const router = express.Router();
@@ -33,13 +33,9 @@ router.patch('/car/:carId/:car', [
   priceOptionalCheck, carIdSanitizer,
 ], Car.markAsSold);
 
-// router.get('/car', [
-//   checkToken, statusQueryCheck, minQueryCheck, maxQueryCheck, arefieldsTheSameQueryCheck,
-// ], Car.getAllUnsoldAvailableCars);
-
 router.get('/car', [
   checkToken, statusQueryCheck, minQueryCheck, maxQueryCheck, arefieldsTheSameQueryCheck,
-  usedStatusQueryCheck,
+  usedStatusQueryCheck, bodyTypeQueryCheck,
 ], Car.getAllUnsoldAvailableCars);
 
 router.get('/car/:carId', [

--- a/test/get.all.cars.specific.body.test.js
+++ b/test/get.all.cars.specific.body.test.js
@@ -1,0 +1,107 @@
+import chai, { expect, use } from 'chai';
+import chaiHttp from 'chai-http';
+import request from 'supertest';
+import server from '../src/server';
+
+
+use(chaiHttp);
+describe('GET /api/v1/car?body_type=coupe', () => {
+  const userCredentials = {
+    email: 'aobikobe@gmail.com',
+    password: 'password70',
+  };
+  const authenticatedUser = request.agent(server);
+  let token;
+
+  before((done) => {
+    authenticatedUser
+      .post('/api/v1/auth/signin')
+      .send(userCredentials)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        token = `Bearer ${res.body.data.token}`;
+        done();
+      });
+  });
+
+
+  describe('When a user tries to retrieve all used cars ommiting status=available', () => {
+    it('should return an object with the status and error', (done) => {
+      chai.request(server)
+        .get('/api/v1/car?body_type').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Body type value is missing');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to retrieve all used cars ommiting status=available', () => {
+    it('should return an object with the status and error', (done) => {
+      chai.request(server)
+        .get('/api/v1/car?body_type=14').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Body type should only contain alphabet');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to retrieve all used cars ommiting status=available', () => {
+    it('should return an object with the status and error', (done) => {
+      chai.request(server)
+        .get('/api/v1/car?status=available&body_type=coupe').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Incorrect number of parameters');
+          done();
+        });
+    });
+  });
+
+
+  describe('When a user tries to retrieve all used cars ommiting status=available', () => {
+    it('should return an object with the status and error', (done) => {
+      chai.request(server)
+        .get('/api/v1/car?body_type=coupe&status=available').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Incorrect number of parameters');
+          done();
+        });
+    });
+  });
+
+
+  describe('When a user tries to retrieve all used cars with proper detail', () => {
+    it('should return an object with the status and data', (done) => {
+      chai.request(server)
+        .get('/api/v1/car?body_type=coupe').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          if (res.body.data.length !== 0) {
+            res.body.data.forEach((element) => {
+              expect(element).to.have.property('id');
+              expect(element).to.have.property('owner');
+              expect(element).to.have.property('createdOn');
+              expect(element).to.have.property('state');
+              expect(element).to.have.property('status');
+              expect(element).to.have.property('bodyType');
+              expect(element).to.have.property('price');
+              expect(element).to.have.property('manufacturer');
+            });
+          }
+          expect(res.body).to.have.property('status').to.equals(201);
+          expect(res.body).to.have.property('data').to.be.a('array');
+
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
What does this PR do?
- User  should be able to retrieve all cars of a specific body type

#### Description of Task to be completed?
- Add test file
- Modify custom-validator with new rule
- Modify route1.js. add validator
- Modify car.js(controller)
- Modify car.js(model)

#### How should this be manually tested?
- ``` npm run start:dev```
- On Postman Browser type
 ``` http:localhost:3000/api/v1/car?body_type=coupe```
- Select Get
- Press send

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166103345](https://www.pivotaltracker.com/story/show/166103345))