### PR TITLE
feat(ui): user should be able to view an advert page as a table

### DIFF
--- a/UI/cars.html
+++ b/UI/cars.html
@@ -378,6 +378,91 @@
 
 
             </div>
+
+            <div id='advert'>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Make</th>
+                            <th scope="col">Model</th>
+                            <th scope="col">Buyer</th>
+                            <th scope="col">Amount</th>
+                            <th scope="col">Paid</th>
+                            <th scope="col">Status</th>
+                            <th scope="col">Date</th>
+                            <th scope="col">button</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td data-label="Account">Buggati</td>
+                            <td data-label="Due Date">2016</td>
+                            <td data-label="Due Date">Seller</td>
+                            <td data-label="Amount">$1,190</td>
+                            <td data-label="Paid">$1,190</td>
+                            <td data-label="Status">Accepted</td>
+                            <td data-label="Period">03/01/2016</td>
+                            <td data-label="img">
+                                <button class='btn  view-po'>
+                                    <span>View </span>
+                                    <img src="img/Long_Arrow_Left_2.ico" alt='filter list' />
+                                </button>
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td data-label="Account">Buggati</td>
+                            <td data-label="Due Date">2016</td>
+                            <td data-label="Due Date">Seller</td>
+                            <td data-label="Amount">$1,190</td>
+                            <td data-label="Paid">$1,190</td>
+                            <td data-label="Status">Accepted</td>
+                            <td data-label="Period">03/01/2016</td>
+                            <td data-label="img">
+                                <button class='btn  view-po'>
+                                    <span>View </span>
+                                    <img src="img/Long_Arrow_Left_2.ico" alt='filter list' />
+                                </button>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td data-label="Account">Buggati</td>
+                            <td data-label="Due Date">2016</td>
+                            <td data-label="Due Date">Seller</td>
+                            <td data-label="Amount">$1,190</td>
+                            <td data-label="Paid">$1,190</td>
+                            <td data-label="Status">Accepted</td>
+                            <td data-label="Period">03/01/2016</td>
+                            <td data-label="img">
+                                <button class='btn  view-po'>
+                                    <span>View </span>
+                                    <img src="img/Long_Arrow_Left_2.ico" alt='filter list' />
+                                </button>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td data-label="Account">Buggati</td>
+                            <td data-label="Due Date">2016</td>
+                            <td data-label="Due Date">Seller</td>
+                            <td data-label="Amount">$1,190</td>
+                            <td data-label="Paid">$1,190</td>
+                            <td data-label="Status">Accepted</td>
+                            <td data-label="Period">03/01/2016</td>
+                            <td data-label="img">
+                                <button class='btn  view-po'>
+                                    <span>View </span>
+                                    <img src="img/Long_Arrow_Left_2.ico" alt='filter list' />
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+
+            </div>
             <div id='gallery'>
 
                 <div class='card'>

--- a/UI/js/pages/advertisement.js
+++ b/UI/js/pages/advertisement.js
@@ -1,7 +1,7 @@
 import Common from './common.js';
-
+const div = document.querySelector('div#advert');
 class Advertisement extends Common {
-  constructor(navigation, galleryHomeDiV) {
+  constructor(navigation, car) {
     super();
 
     this.name = 'adv';
@@ -22,14 +22,26 @@ class Advertisement extends Common {
       }
     });
 
-    this.galleryHomeDiV = galleryHomeDiV;
+    div.style.display = 'none';
+    const buttons = document.querySelectorAll('.view-po');
+    buttons.forEach(
+
+      (button) => {
+        button.addEventListener('click', (ev) => {
+          navigation.setCurrentPage(car);
+          ev.preventDefault();
+        });
+      },
+
+    );
+
   }
 
   showPage() {
     this.navigation.setPageType('adv');
     this.advDiv.style.display = 'flex';
     this.advDiv.classList.remove('is-not-visible');
-    this.galleryHomeDiV.showPage();
+    div.style.display = 'block';
   }
 
   getName() {
@@ -39,7 +51,7 @@ class Advertisement extends Common {
   removePage() {
     this.advDiv.style.display = 'none';
     this.advDiv.classList.add('is-not-visible');
-    this.galleryHomeDiV.removePage();
+    div.style.display = 'none';
   }
 }
 

--- a/UI/js/pages/purchasepage.js
+++ b/UI/js/pages/purchasepage.js
@@ -6,9 +6,9 @@ class PurchaseOrderPage extends Common {
     super();
 
     this.name = 'po';
-    const buttons = document.querySelectorAll('.view-po');
     this.navigation = navigation;
     div.style.display = 'none';
+    const buttons = document.querySelectorAll('.view-po');
     buttons.forEach(
 
       (button) => {

--- a/UI/js/script2.js
+++ b/UI/js/script2.js
@@ -85,7 +85,7 @@ const startApp = () => {
 
   const homePage = new HomePage(navigation, galleryDiv);
   const purchaseOrderPage = new PurchaseOrderPage(navigation, car);
-  const advertisement = new Advertisement(navigation, galleryDiv);
+  const advertisement = new Advertisement(navigation, car);
   const adminPage = new AdminPage(navigation, galleryDiv);
 
   navigation.setCurrentPage(homePage);


### PR DESCRIPTION
What does this PR do?
- User  should be able  to view an advert page as a table

#### Description of Task to be completed?
- Add div for advert
- Add table
- Modify advertisement.js with eventlistener

#### How should this be manually tested?
- Start web server on localhost
- Navigate to http://127.0.0.1:{port_number}/UI/cars.html on web browser
- Click the your ads tab

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166612163](https://www.pivotaltracker.com/story/show/166612163))