### PR TITLE
feat(api-v2): user should be able to create a car sale advert

### DIFF
--- a/src/controllers/v2/car.js
+++ b/src/controllers/v2/car.js
@@ -1,0 +1,82 @@
+import url from 'url';
+import cloudinary from 'cloudinary';
+import formidable from 'formidable';
+import CarService from '../../services/controller/car';
+import Result from '../../helpers/result';
+// import Validator from '../../helpers/validator';
+
+
+class Car {
+  static async postCarAd(req, res) {
+    new formidable.IncomingForm().parse(req, async (err, fields, files) => {
+      const { dataFile } = files;
+      if (!dataFile) {
+        return res.status(400).json({ status: 400, error: 'Invalid File name parameter supplied' });
+      }
+      const validation = Car.validation(dataFile, fields);
+      if (validation.error) {
+        return res.status(400).json({ status: 400, error: validation.error });
+      }
+      const cloudinaryUrl = url.parse(process.env.CLOUDINARY_URL);
+
+      cloudinary.config({
+        cloud_name: cloudinaryUrl.host,
+        api_key: cloudinaryUrl.auth.split(':')[0],
+        api_secret: cloudinaryUrl.auth.split(':')[1],
+      });
+      return cloudinary.v2.uploader
+        .upload(dataFile.path, { tags: 'gotemps', resource_type: 'auto' })
+        .then(async (file) => {
+          const carObject = await CarService.createCar(fields, req.user.id, file.url);
+          const ers = Promise.resolve(carObject);
+          return ers.then(
+            cars => Result.getResult(res, cars, false, 201),
+          );
+        });
+    });
+  }
+
+  static validation(dataFile, fields) {
+    const type = dataFile.type.substr(6);
+
+    if (!['png', 'jpg', 'jpeg', 'gif'].includes(type)) {
+      return { error: 'Allowed File type [\'png\', \'jpg\', \'jpeg\', \'gif\']' };
+    }
+
+    if (dataFile.size > 409600) {
+      return { error: 'File Size should not exceed 400KB' };
+    }
+
+    if (!fields.state) {
+      return { error: 'State Field is missing' };
+    }
+
+    if (fields.state !== 'new' && fields.state !== 'used') {
+      return { error: 'State Field must be new or old' };
+    }
+
+    if (!fields.manufacturer) {
+      return { error: 'Manufacturer Field is missing' };
+    }
+
+    if (!fields.price) {
+      return { error: 'Price Field does not exist' };
+    }
+    const price = Number.parseFloat(fields.price);
+    if (Number.isNaN(price) || price <= 0) {
+      return { error: 'Price Field must be a positive number' };
+    }
+
+    if (!fields.bodyType) {
+      return { error: 'Body Type Field does not exist' };
+    }
+
+    if (!fields.model) {
+      return { error: 'Model Field does not exist' };
+    }
+
+    return '';
+  }
+}
+
+export default Car;

--- a/src/routes/route2.js
+++ b/src/routes/route2.js
@@ -1,9 +1,10 @@
 import express from 'express';
 import User from '../controllers/v2/user';
+import Car from '../controllers/v2/car';
 
 import {
   emailCheck, passwordCheck, firstNameCheck, lastNameCheck,
-  addressCheck,
+  addressCheck, checkToken,
 } from '../helpers/custom-validator';
 
 
@@ -22,5 +23,7 @@ router2.post('/auth/signin', [
   emailCheck,
   passwordCheck,
 ], User.signIn);
+
+router2.post('/car', checkToken, Car.postCarAd);
 
 export default router2;

--- a/src/services/controller/car.js
+++ b/src/services/controller/car.js
@@ -1,0 +1,30 @@
+import { query } from '../db/index';
+
+class CarService {
+  static createCar(body, userId, url) {
+    const getCarPromise = CarService.createCarQuery(body, userId, url);
+    return getCarPromise.then(
+      data => data,
+    );
+  }
+
+  static async createCarQuery(body, userId, url) {
+    const queryString = 'INSERT INTO cars (owner,state,status, price, manufacturer, model, body_type, url) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *; ';
+    const value = [
+      userId,
+      body.state,
+      'available',
+      body.price,
+      body.manufacturer,
+      body.model,
+      body.bodyType,
+      url,
+    ];
+    const { rows } = await query(queryString, value);
+    const { created_on: createdOn, body_type: bodyType, ...rest } = rows[0];
+
+    return { ...rest, bodyType, createdOn };
+  }
+}
+
+export default CarService;

--- a/src/services/db/index.js
+++ b/src/services/db/index.js
@@ -1,7 +1,7 @@
 import pg from 'pg';
 import dotenv from 'dotenv';
-import { userTable } from './migration';
-import { userSeed } from './seed';
+import { userTable, carTable } from './migration';
+import { userSeed, carSeed } from './seed';
 import '@babel/polyfill';
 
 dotenv.config();
@@ -33,14 +33,14 @@ const createTables = (table) => {
 };
 
 const dropTables = () => {
-  query('DROP TABLE users;', [])
+  query('DROP TABLE users, cars;', [])
     .then((res) => {
       console.log('table dropped');
       // pool.end();
     });
 };
 
-createTables(userTable + userSeed);
+createTables(userTable + carTable + userSeed + carSeed);
 
 export {
 

--- a/src/services/db/migration.js
+++ b/src/services/db/migration.js
@@ -7,7 +7,20 @@ const userTable = `CREATE TABLE IF NOT EXISTS  users
     address TEXT,
     is_admin BOOLEAN ); `;
 
+const carTable = `CREATE TABLE IF NOT EXISTS cars 
+    (id serial PRIMARY KEY, 
+        owner BIGINT NOT NULL,
+        created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        state TEXT CHECK ( state IN ('new','used') ),
+        status TEXT CHECK ( status IN ('sold','available') ),
+        price FLOAT,
+        manufacturer VARCHAR(40) NOT NULL,
+        model VARCHAR(40) NOT NULL,
+        body_type VARCHAR(40) NOT NULL,
+        url TEXT NOT NULL,
+        CONSTRAINT ct_owner FOREIGN KEY (owner) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE);`;
+
 export {
 
-  userTable,
+  userTable, carTable,
 };

--- a/src/services/db/seed.js
+++ b/src/services/db/seed.js
@@ -11,7 +11,27 @@ const userSeed = `
      
     `;
 
-module.exports = {
+const url = 'http://res.cloudinary.com/blueandblack/image/upload/v1558957073/lz1rztg8vkvpfyffgsrv.jpg';
 
-  userSeed,
+const carSeed = `
+        INSERT INTO cars (owner,state,status, price, manufacturer, model, body_type, url) VALUES 
+        ( 1,'new', 'available', 1.4, 'mercedes', '2014', 'trailer','${url}'),
+        ( 2,'used', 'available', 1.8, 'honda', '2015', 'coupe','${url}'),
+        ( 3,'used', 'available', 2.8, 'mercedes', '2014', 'trailer','${url}'),
+        ( 1,'new', 'sold', 1.4, 'mercedes', '2016', 'coupe','${url}'),
+        ( 3,'used', 'available', 3.2, 'mercedes', '2014', 'saloon','${url}'),
+        ( 3,'used', 'available', 4.7, 'toyota', '2018', 'saloon','${url}'),
+        ( 3,'used', 'available', 5.4, 'mercedes', '2014', 'trailer','${url}'),
+        ( 1,'used', 'sold', 1.4, 'volkswagen', '1998', 'saloon','${url}'),
+        ( 1,'used', 'available', 6.4, 'hyundai', '2014', 'mpv','${url}'),
+        ( 1,'used', 'available', 9.4, 'buggati', '2011', 'trailer','${url}'),
+        ( 1,'used', 'available', 11.4, 'mercedes', '2013', 'trailer','${url}'),
+        ( 1,'used', 'available', 12.4, 'dodge', '2015', 'suv','${url}'),
+        ( 1,'used', 'sold', 1.5, 'ferari', '2014', 'trailer','${url}'),
+        ( 1,'used', 'available', 1.6, 'maclaren', '2014', 'coupe','${url}')
+        ;
+       `;
+
+export {
+  userSeed, carSeed,
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -19,4 +19,5 @@
 --file ./test/v1/create.car.ad.test.js
 --file ./test/v2/sign.in.test.js
 --file ./test/v2/sign.up.user.test.js
+--file ./test/v2/create.car.ad.test.js
 --file ./test/v2/teardown.js

--- a/test/v2/create.car.ad.test.js
+++ b/test/v2/create.car.ad.test.js
@@ -1,0 +1,322 @@
+import chai, { expect, use } from 'chai';
+import chaiHttp from 'chai-http';
+import request from 'supertest';
+import server from '../../src/server';
+
+use(chaiHttp);
+
+describe('POST /api/v2/car', () => {
+  const userCredentials = {
+    email: 'aobikobe@gmail.com',
+    password: 'password70',
+  };
+  const authenticatedUser = request.agent(server);
+  let token;
+
+  before((done) => {
+    authenticatedUser
+      .post('/api/v2/auth/signin')
+      .send(userCredentials)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        token = `Bearer ${res.body.data.token}`;
+        done();
+      });
+  });
+
+  describe('When a user tries to make a car ad with no state field supplied', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('State Field is missing');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with an invalid state field type', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 45,
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('State Field must be new or old');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with no price field supplied', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Price Field does not exist');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with invalid price field type', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 'amaobi',
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Price Field must be a positive number');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with no model field', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Model Field does not exist');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with no body type field supplied', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Body Type Field does not exist');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with no manufacturer field supplied', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Manufacturer Field is missing');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with no image supplied', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', '')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with missing dataFile field', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('datasFile', 'test/img/img1.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with an image size larger than 400kb', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img2.jpg')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('File Size should not exceed 400KB');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to make a car ad with an invalid image type', () => {
+    it('should return an object with the status and error', (done) => {
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/song.mp3')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(400);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Allowed File type [\'png\', \'jpg\', \'jpeg\', \'gif\']');
+          done();
+        });
+    });
+  });
+
+  describe('When a user tries to upload a new car with valid detail', () => {
+    // eslint-disable-next-line func-names
+    it('should return an object with the status and data', function (done) {
+      this.timeout(50000);
+      const data = {
+        state: 'new',
+        price: 1200000,
+        model: '2018',
+        bodyType: 'coupe',
+        manufacturer: 'maclaren',
+      };
+
+
+      chai.request(server)
+        .post('/api/v2/car').set('Authorization', token)
+        .field('Content-Type', 'multipart/form-data')
+        .field(data)
+        .attach('dataFile', 'test/img/img1.jpg')
+        .type('form')
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(201);
+          expect(res.body).to.have.property('data').to.be.a('object');
+          expect(res.body).to.have.property('data').to.have.property('id');
+          expect(res.body).to.have.property('data').to.have.property('owner');
+          expect(res.body).to.have.property('data').to.have.property('createdOn');
+          expect(res.body).to.have.property('data').to.have.property('state');
+          expect(res.body).to.have.property('data').to.have.property('status').to.be.equals('available');
+          expect(res.body).to.have.property('data').to.have.property('price');
+          expect(res.body).to.have.property('data').to.have.property('manufacturer');
+          expect(res.body).to.have.property('data').to.have.property('model');
+          expect(res.body).to.have.property('data').to.have.property('bodyType');
+          expect(res.body).to.have.property('data').to.have.property('url');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
What does this PR do?
- User  should be able to create a car sale advert

#### Description of Task to be completed?
- Add test file
- Modify router to accommodate endpoint
- Add database table
- Add seed files
- Add controller file for creating car advert
- Add car service file

#### How should this be manually tested?
- ``` npm run start:dev```
- On Postman Browser type
 ``` http:localhost:300/api/v2/car```
- Select Post
- Select Body
- Select form-data
- Type in the fields with their respective parameter
- Press send

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166735111](https://www.pivotaltracker.com/story/show/166735111))