### PR TITLE
feat(api-v2): user should be able to retrieve all cars as an admin

### DIFF
--- a/src/controllers/v2/car.js
+++ b/src/controllers/v2/car.js
@@ -40,9 +40,9 @@ class Car {
     const error = Validator.validate(req, res);
     if (error) return error;
 
-    // const {
-    //   status, state, manufacturer,
-    // } = req.query;
+    const {
+      status, state, manufacturer,
+    } = req.query;
 
     // const min = req.query.min_price;
     // const max = req.query.max_price;
@@ -55,7 +55,7 @@ class Car {
       return res.status(400).json({ status: 400, error: 'Invalid Query Parameter was supplied' });
     }
 
-    // let carObject;
+    let carObject;
 
     // if (bodyType) {
     //   carObject = await CarService.getAllCarsByBodyType(bodyType);
@@ -65,12 +65,12 @@ class Car {
     //   carObject = await CarService.getAllUnsoldAvailableCarsByRange(min, max);
     // } else if (state && (state === 'used' || state === 'new')) {
     //   carObject = await CarService.getAllUnsoldAvailableCars(state);
-    // } else if (status && !state) {
-    //   carObject = await CarService.getAllUnsoldAvailableCars();
-    // } else {
-    //   carObject = await CarService.getAllCars(req.user.isAdmin);
-    // }
-    const carObject = await CarService.getAllUnsoldAvailableCars();
+    // } else 
+    if (status && !state) {
+      carObject = await CarService.getAllUnsoldAvailableCars();
+    } else {
+      carObject = await CarService.getAllCars(req.user.isAdmin);
+    }
 
     const result = Promise.resolve(carObject);
 

--- a/src/services/controller/car.js
+++ b/src/services/controller/car.js
@@ -27,6 +27,16 @@ class CarService {
     );
   }
 
+  static getAllCars(isAdmin) {
+    if (!isAdmin) {
+      return { code: 403, error: 'Only an admin is allowed retrieve all cars' };
+    }
+    const getCarPromise = CarService.getAllCarsQuery();
+    return getCarPromise.then(
+      data => data,
+    );
+  }
+
   static async createCarQuery(body, userId, url) {
     const queryString = 'INSERT INTO cars (owner,state,status, price, manufacturer, model, body_type, url) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *; ';
     const value = [
@@ -53,15 +63,24 @@ class CarService {
       queryString += ' AND state = $1';
       value = [state];
     }
-    const { rows } = await query(queryString, value);
-    const result = [];
-    rows.forEach((row) => {
-      const { created_on: createdOn, body_type: bodyType, ...rest } = row;
+    // const { rows } = await query(queryString, value);
+    // const result = [];
+    // rows.forEach((row) => {
+    //   const { created_on: createdOn, body_type: bodyType, ...rest } = row;
 
-      result.push({ ...rest, bodyType, createdOn });
-    });
+    //   result.push({ ...rest, bodyType, createdOn });
+    // });
 
-    return result;
+    // return result;
+    return CarService.customQuery(queryString, value);
+  }
+
+  static async getAllCarsQuery() {
+    const queryString = 'SELECT * FROM cars';
+    const value = [];
+    // const { rows } = await query(queryString, value);
+    // return rows;
+    return CarService.customQuery(queryString, value);
   }
 
   static async getSingleCarQuery(carId) {
@@ -72,6 +91,18 @@ class CarService {
     const { rows } = await query(queryString, value);
 
     return rows[0];
+  }
+
+  static async customQuery(queryString, value) {
+    const { rows } = await query(queryString, value);
+    const result = [];
+    rows.forEach((row) => {
+      const { created_on: createdOn, body_type: bodyType, ...rest } = row;
+
+      result.push({ ...rest, bodyType, createdOn });
+    });
+
+    return result;
   }
 }
 

--- a/test/v2/get.all.cars.test.js
+++ b/test/v2/get.all.cars.test.js
@@ -1,0 +1,85 @@
+import chai, { expect, use } from 'chai';
+import chaiHttp from 'chai-http';
+import request from 'supertest';
+import server from '../../src/server';
+
+
+use(chaiHttp);
+describe('GET /api/v2/car/', () => {
+  const userCredentials = {
+    email: 'aobikobe@gmail.com',
+    password: 'password70',
+  };
+  const authenticatedUser = request.agent(server);
+  let token;
+
+  before((done) => {
+    authenticatedUser
+      .post('/api/v2/auth/signin')
+      .send(userCredentials)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        token = `Bearer ${res.body.data.token}`;
+        done();
+      });
+  });
+
+  describe('When a user that is an admin attempts to retrieve all cars', () => {
+    it('should return an object with the status and data', (done) => {
+      chai.request(server)
+        .get('/api/v2/car').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          if (res.body.data.length !== 0) {
+            res.body.data.forEach((element) => {
+              expect(element).to.have.property('id');
+              expect(element).to.have.property('owner');
+              expect(element).to.have.property('createdOn');
+              expect(element).to.have.property('state');
+              expect(element).to.have.property('status');
+              expect(element).to.have.property('price');
+              expect(element).to.have.property('manufacturer');
+            });
+          }
+          expect(res.body).to.have.property('status').to.equals(200);
+          expect(res.body).to.have.property('data').to.be.a('array');
+
+          done();
+        });
+    });
+  });
+});
+
+
+describe('GET /api/v2/car/', () => {
+  const userCredentials = {
+    email: 'victorvents@hotmail.com',
+    password: 'password70',
+  };
+  const authenticatedUser = request.agent(server);
+  let token;
+
+  before((done) => {
+    authenticatedUser
+      .post('/api/v2/auth/signin')
+      .send(userCredentials)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        token = `Bearer ${res.body.data.token}`;
+        done();
+      });
+  });
+
+  describe('When a user that is not an admin tries to retrieve all cars', () => {
+    it('should return an object with the status and error', (done) => {
+      chai.request(server)
+        .get('/api/v2/car').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          expect(res.body).to.have.property('status').to.equals(403);
+          expect(res.body).to.have.property('error').to.be.a('string').equals('Only an admin is allowed retrieve all cars');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
What does this PR do?
- User  should be able to retrieve all cars as an admin

#### Description of Task to be completed?
- Add test file
- Modify controller file for car
- Modify car service file

#### How should this be manually tested?
- ``` npm run start:dev```
- On Postman Browser type
 ``` http:localhost:3000/api/v2/car```
- Select Get
- Press send

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166734964](https://www.pivotaltracker.com/story/show/166734964))