### PR TITLE
feat(api-v2): user should be able to retrieve incoming purchase order

### DIFF
--- a/src/controllers/v2/order.js
+++ b/src/controllers/v2/order.js
@@ -32,5 +32,20 @@ class Order {
       order => Result.getResult(res, order, false, 200),
     );
   }
+
+  static async getOrder(req, res) {
+    const error = Validator.validate(req, res);
+
+    if (error) return error;
+
+
+    const orderObject = await OrderService.getOrder(req.user.id);
+
+    const result = Promise.resolve(orderObject);
+
+    return result.then(
+      order => Result.getResult(res, order, true, 200),
+    );
+  }
 }
 export default Order;

--- a/src/routes/route2.js
+++ b/src/routes/route2.js
@@ -53,6 +53,10 @@ router2.get('/car/:carId', [
   checkToken, carIdParamCheck, carIdSanitizer,
 ], Car.getSingleCar);
 
+router2.get('/order/seller', [
+  checkToken,
+], Order.getOrder);
+
 router2.delete('/car/:carId', [
   checkToken, carIdParamCheck, carIdSanitizer,
 ], Car.getDeleteCar);

--- a/src/services/controller/order.js
+++ b/src/services/controller/order.js
@@ -104,6 +104,13 @@ class OrderService {
     };
   }
 
+  static getOrder(userId) {
+    const getCarPromise = OrderService.getOrderQuery(userId);
+    return getCarPromise.then(
+      data => data,
+    );
+  }
+
   static async doesOrderExist(carId, userId) {
     const queryString = 'SELECT id FROM orders WHERE car_id = $1 AND buyer= $2 ;';
     const value = [carId, userId];
@@ -118,6 +125,27 @@ class OrderService {
     const { rows } = await query(queryString, value);
     if (rows.length === 0) { return false; }
     return rows[0];
+  }
+
+  static async getOrderQuery(id) {
+    // const queryString = 'SELECT cars.owner,cars.status as carstatus,orders.status as orderstatus FROM orders INNER JOIN cars ON cars.id = orders.car_id WHERE cars.id = $1;';
+    const queryString = 'SELECT orders.id, cars.id as carid,buyer, orders.amount,cars.price, cars.owner,orders.status,orders.created_on FROM orders INNER JOIN cars ON cars.id = orders.car_id WHERE cars.owner = $1;';
+    const value = [id];
+    const { rows } = await query(queryString, value);
+    const result = [];
+    rows.forEach((row) => {
+      const {
+        carid: carId,
+        amount: priceOffered,
+        created_on: createdOn, body_type: bodyType, ...rest
+      } = row;
+
+      result.push({
+        ...rest, bodyType, createdOn, carId, priceOffered,
+      });
+    });
+
+    return result;
   }
 }
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -34,4 +34,5 @@
 --file ./test/v2/update.order.test.js
 --file ./test/v2/delete.specific.car.test.js
 --file ./test/v2/create.flag.test.js
+--file ./test/v2/get.purchase.order.request.test.js
 --file ./test/v2/teardown.js

--- a/test/v2/get.purchase.order.request.test.js
+++ b/test/v2/get.purchase.order.request.test.js
@@ -1,0 +1,51 @@
+import chai, { expect, use } from 'chai';
+import chaiHttp from 'chai-http';
+import request from 'supertest';
+import server from '../../src/server';
+
+use(chaiHttp);
+
+describe('GET /api/v2/order/seller', () => {
+  const userCredentials = {
+    email: 'aobikobe@gmail.com',
+    password: 'password70',
+  };
+  const authenticatedUser = request.agent(server);
+  let token;
+
+  before((done) => {
+    authenticatedUser
+      .post('/api/v2/auth/signin')
+      .send(userCredentials)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        token = `Bearer ${res.body.data.token}`;
+        done();
+      });
+  });
+
+
+  describe('Get all purchase order for car', () => {
+    it('should return an object with the status and data', (done) => {
+      chai.request(server)
+        .get('/api/v2/order/seller').set('Authorization', token)
+        .send()
+        .end((err, res) => {
+          if (res.body.data.length !== 0) {
+            res.body.data.forEach((element) => {
+              expect(element).to.have.property('id');
+              expect(element).to.have.property('carId');
+              expect(element).to.have.property('createdOn');
+              expect(element).to.have.property('priceOffered');
+              expect(element).to.have.property('price');
+              expect(element).to.have.property('buyer');
+            });
+          }
+          expect(res.body).to.have.property('status').to.equals(200);
+          expect(res.body).to.have.property('data').to.be.a('array');
+
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
What does this PR do?
- User  should be able to retrieve incoming purchase order

#### Description of Task to be completed?
- Add test file
- Modify route validator for this endpoint
- Add controller file for this endpoint
- Add service file for this endpoint

#### How should this be manually tested?
- ``` npm run start:dev```
- On Postman Browser type
 ``` http:localhost:3000/api/v2/order/seller```
- Select Get
- Press send

#### What are the relevant pivotal tracker stories?
- PT Story link - ([166763032](https://www.pivotaltracker.com/story/show/166763032))